### PR TITLE
쿠키값에 "@"문자가 포함되면 서블릿이 a@a.com을 "a@a.com"으로 변환함 (따옴표 앞뒤로 붙임).

### DIFF
--- a/jakduk-common/src/com/jakduk/service/CommonService.java
+++ b/jakduk-common/src/com/jakduk/service/CommonService.java
@@ -1,18 +1,15 @@
 package com.jakduk.service;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.regex.Pattern;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.jakduk.authentication.common.CommonUserDetails;
+import com.jakduk.authentication.common.OAuthPrincipal;
+import com.jakduk.authentication.jakduk.JakdukPrincipal;
+import com.jakduk.common.CommonConst;
 import com.jakduk.dao.JakdukDAO;
 import com.jakduk.model.db.FootballClub;
 import com.jakduk.model.db.FootballClubOrigin;
+import com.jakduk.model.db.Sequence;
 import com.jakduk.repository.FootballClubOriginRepository;
+import com.jakduk.repository.SequenceRepository;
 import org.apache.log4j.Logger;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,14 +23,20 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import com.jakduk.authentication.common.CommonUserDetails;
-import com.jakduk.authentication.common.OAuthPrincipal;
-import com.jakduk.authentication.jakduk.JakdukPrincipal;
-import com.jakduk.common.CommonConst;
-import com.jakduk.model.db.Sequence;
-import com.jakduk.repository.FootballClubRepository;
-import com.jakduk.repository.SequenceRepository;
-import org.springframework.ui.Model;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * @author <a href="mailto:phjang1983@daum.net">Jang,Pyohwan</a>
@@ -187,10 +190,14 @@ public class CommonService {
 	}
 	
 	public void setCookie(HttpServletResponse response, String name, String value, String path) {
-		Cookie cookie = new Cookie(name, value);
-		cookie.setMaxAge(CommonConst.COOKIE_EMAIL_MAX_AGE); // a day
-		cookie.setPath(path);
-		response.addCookie(cookie);		
+		try {
+			Cookie cookie = new Cookie(name, URLEncoder.encode(value, "UTF-8"));
+			cookie.setMaxAge(CommonConst.COOKIE_EMAIL_MAX_AGE); // a day
+			cookie.setPath(path);
+			response.addCookie(cookie);
+		} catch (UnsupportedEncodingException e) {
+			logger.error(e);
+		}
 	}
 	
 	public void releaseCookie(HttpServletResponse response, String name, String path) {


### PR DESCRIPTION
브라우저에서 쿠키값을 사용할 때 앞뒤 따옴표를 걸러내야 하는 문제 발생.
쿠키 하위 호환 문제로 하위 버전은 "@"말고도 지원하지 않는 문자가 있기 때문에  모든 쿠키값에 URL인코딩 적용.
http://stackoverflow.com/questions/14582334/java-cookies-and-double-quoted-marks?answertab=votes#tab-top

![2016-01-03 12 19 31](https://cloud.githubusercontent.com/assets/860087/12074874/b00e330c-b1af-11e5-932b-5510dd5f70e4.png)
