### PR TITLE
Finished fixing flaky test

### DIFF
--- a/src/test/java/com/jakduk/api/GalleryOnListTest.java
+++ b/src/test/java/com/jakduk/api/GalleryOnListTest.java
@@ -158,17 +158,17 @@ public class GalleryOnListTest {
 
 		ObjectMapper mapper = new ObjectMapper();
 
-		String expectResult = "[{\"uid\":\"a1\",\"size\":100,\"name\":\"test01\"},{\"uid\":\"a2\",\"size\":200,\"name\":\"test02\"}]";
+		String expectResult = "[{\"uid\":\"a1\",\"name\":\"test01\",\"size\":100},{\"uid\":\"a2\",\"name\":\"test02\",\"size\":200}]";
 
 		List<Map<String, Object>> images = new ArrayList<>();
 
-		Map<String, Object> image01 = new HashMap<>();
+		Map<String, Object> image01 = new LinkedHashMap<>();
 		image01.put("uid", "a1");
 		image01.put("name", "test01");
 		image01.put("size", 100);
 		images.add(image01);
 
-		Map<String, Object> image02 = new HashMap<>();
+		Map<String, Object> image02 = new LinkedHashMap<>();
 		image02.put("uid", "a2");
 		image02.put("name", "test02");
 		image02.put("size", 200);


### PR DESCRIPTION
## Changes proposed
  Test```com.jakduk.api.GalleryOnListTest.자바배열객체를_JSON문자열로변환``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```assertEquals(expectResult, result);``` at line 179. The flakiness was resulted from the random order of the fields stored inside the Hashmaps ``` image01``` and ```image02```. The ```expectedResult``` used in the unit test was defined using a string with fixed order, and it will not match the ```result``` generated by ```mapper.writeValueAsString(images);```. The error messages:
  ```
  org.opentest4j.AssertionFailedError: expected: <[{"uid":"a1","name":"test01","size":100},{"uid":"a2","name":"test02","size":200}]> but was: <[{"uid":"a1","size":100,"name":"test01"},{"uid":"a2","size":200,"name":"test02"}]>
          at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
          at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
          at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
          at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
          at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
          at com.jakduk.api.GalleryOnListTest.자바배열객체를_JSON문자열로변환(GalleryOnListTest.java:179)
  ```
  
  ## Fix of the problem
  The fix was rather simple. Since it was totally due to the property of HashMap where its fields are stored in random orders. I changed the data structures of ``images01``` and ```images02``` from HashSet to LinkedHashSet. Besides, I modified the order of the ```expectedResult``` to match the sorted values of the LinkedHashMaps.
  
  ## Result of the fix
  The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed
  
  ## Test Environment:
  Gradle 7.2
  java OpenJDK 1.8.0_382
  Linux 5.4.0-166-generic amd64